### PR TITLE
ci: test with Node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.node-version == '26' }}
 
     strategy:
       matrix:
-        node-version: ['16', '18', '20']
+        node-version: ['22', '24', '26']
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/croutonn/graphql-codegen-plugin-typescript-swr",
   "license": "MIT",
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=22.0.0"
   },
   "keywords": [
     "graphql",


### PR DESCRIPTION
## Summary
- Run CI on Node.js 22, 24, and 26.
- Allow the Node.js 26 CI job to fail without failing the workflow.
- Declare Node.js 22 as the minimum supported version.

## Testing
- yarn test