### PR TITLE
chore(release): bump version to 0.8.6, add prepublishOnly guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-codegen-plugin-typescript-swr",
-  "version": "0.8.5",
+  "version": "0.8.6",
   "description": "A GraphQL code generator plug-in that automatically generates utility functions for SWR.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",
@@ -23,6 +23,7 @@
     "build": "run-p build:*",
     "build:main": "tsc -p tsconfig.main.json",
     "build:module": "tsc -p tsconfig.module.json",
+    "prepublishOnly": "yarn build",
     "fix": "run-s fix:*",
     "fix:prettier": "prettier \"src/**/*.ts\" --write",
     "fix:lint": "eslint src --ext .ts --fix",


### PR DESCRIPTION
## Summary
- Bump `package.json` version from `0.8.5` to `0.8.6`.
- Add a `prepublishOnly": "yarn build"` script so `npm publish` always rebuilds `build/main` and `build/module` first, regardless of local working-tree state.

## Why
`build/` is gitignored and nothing previously forced a rebuild before publishing. That's exactly how #224 happened: v0.8.4 was published with `build/` missing/stale, breaking `main`/`module`/`typings` resolution for every consumer until v0.8.5 fixed it. This PR adds a structural guard so that class of failure can't recur silently.

Verified locally with `npm pack --dry-run` that the resulting tarball for `0.8.6` contains `build/main/*` and `build/module/*` as expected.

No functional changes to `src/` since `v0.8.5` — only dependency bumps and the new `sample/` app (excluded from the published package via the `files` field).

## After merging this PR
1. Pull `main` locally and confirm `git log -1` matches the merge commit.
2. Tag the release: `git tag v0.8.6` on the merge commit, then `git push origin v0.8.6`.
3. Run `yarn install --pure-lockfile && yarn test` one more time on a clean checkout of `main` at the tag.
4. Run `npm pack --dry-run` again and confirm `build/main/` and `build/module/` are present in the tarball (this is the #224 regression check — do not skip it).
5. Publish: `npm publish`.
6. Verify the registry matches: `npm view graphql-codegen-plugin-typescript-swr version` should print `0.8.6`, and `package.json` on `main` should already say `0.8.6` (avoids the drift that #227 had to fix after the fact).
7. Create the GitHub Release for tag `v0.8.6` (see notes below).

## GitHub Release notes (for v0.8.6)
Following the same format as the v0.8.5/v0.8.4/v0.8.3 releases (a manual `## Summary`, then GitHub's auto-generated `## What's Changed` / `**Full Changelog**`):

```
## Summary

- Add a `prepublishOnly` script so `npm publish` always rebuilds before packing. This closes the gap that caused #224 (v0.8.4 was published with the build output missing/stale).
- Otherwise dependency updates only; no functional changes to `src/` since v0.8.5.

## What's Changed
* ci: test with Node 22 by @eitoball in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/233
* feat(sample): add local smoke-test app for dependency updates by @eitoball in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/234
* chore(deps): update dependency ts-jest to v29.4.12 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/226
* chore(deps): update dependency eslint-import-resolver-typescript to v3.10.1 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/225
* chore(deps): update dependency @graphql-codegen/plugin-helpers to v2.7.2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/216
* chore(deps): update dependency @graphql-codegen/typescript to v2.8.8 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/218
* chore(deps): update dependency @graphql-codegen/typescript-graphql-request to v4.5.9 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/219
* chore(deps): update dependency @graphql-codegen/typescript-operations to v2.5.13 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/220
* chore(deps): update dependency @graphql-codegen/visitor-plugin-common to v2.13.8 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/221
* chore(release): bump version to 0.8.6, add prepublishOnly guard by @eitoball in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/244

**Full Changelog**: https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/compare/v0.8.5...v0.8.6
```

Note: the `What's Changed` list above was generated via `gh api repos/croutonn/graphql-codegen-plugin-typescript-swr/releases/generate-notes -f tag_name=v0.8.6 -f previous_tag_name=v0.8.5` against the state at PR creation time, with #227 and #229 dropped since those already belong to the v0.8.5 changes. Re-run that command (or `gh release create v0.8.6 --generate-notes --notes-start-tag v0.8.5`) after merging to pick up anything merged afterward, then prepend the `## Summary` section by hand as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
