### PR TITLE
chore(release): bump version to 0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-codegen-plugin-typescript-swr",
-  "version": "0.8.6",
+  "version": "0.9.0",
   "description": "A GraphQL code generator plug-in that automatically generates utility functions for SWR.",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",


### PR DESCRIPTION
## Summary

- Bump `package.json` version from `0.8.6` to `0.9.0`.
- Includes the `swr` v1→v2 and `graphql-request` v4→v6 dependency upgrades merged since `v0.8.6` (peer dependency changes, hence the minor bump rather than a patch), plus routine devDependency updates.
- No changes to `src/` beyond what those dependency upgrades required.

Verified locally: `yarn test` (build + lint + prettier + jest) passes, and `npm pack --dry-run` shows `build/main/` and `build/module/` present in the tarball.

## What's Changed
* chore(deps): update dependency swr to v2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/211
* chore(deps): upgrade graphql-request to v6 by @eitoball in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/245
* chore(deps): update dependency micromatch to v4.0.8 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/230
* chore(deps): update dependency @typescript-eslint/eslint-plugin to v5.62.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/236
* chore(deps): update dependency @typescript-eslint/parser to v5.62.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/237
* chore(deps): update dependency eslint to v8.57.1 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/238
* chore(deps): update dependency eslint-config-airbnb-typescript to v17.1.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/239
* chore(deps): update dependency eslint-config-prettier to v8.10.2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/240
* chore(deps): update dependency eslint-plugin-import to v2.32.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/241
* chore(deps): update dependency eslint-plugin-jsx-a11y to v6.10.2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/246
* chore(deps): update dependency eslint-plugin-react to v7.37.5 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/247
* chore(deps): update dependency eslint-plugin-react-hooks to v4.6.2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/248
* chore(deps): update dependency jest to v29.7.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/250
* chore(deps): update dependency jest-docblock to v29.7.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/251
* chore(deps): update dependency prettier to v2.8.8 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/252
* chore(release): bump version to 0.9.0 by @eitoball in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/255

**Full Changelog**: https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/compare/v0.8.6...v0.9.0

## After merging this PR
1. Pull `main` locally and confirm `git log -1` matches the merge commit.
2. Tag the release: `git tag v0.9.0` on the merge commit, then `git push origin v0.9.0`.
3. Run `yarn install --pure-lockfile && yarn test` one more time on a clean checkout of `main` at the tag.
4. Run `npm pack --dry-run` again and confirm `build/main/` and `build/module/` are present in the tarball.
5. Publish: `npm publish`.
6. Verify the registry matches: `npm view graphql-codegen-plugin-typescript-swr version` should print `0.9.0`.
7. Create the GitHub Release for tag `v0.9.0` (see notes below).

## GitHub Release notes (for v0.9.0)
Following the same format as recent releases (a manual `## Summary`, then GitHub's auto-generated `## What's Changed` / `**Full Changelog**`):

```
## Summary

- Upgrade `swr` from v1 to v2 and `graphql-request` from v4 to v6. Both are peer/runtime dependency upgrades with breaking changes upstream, so this is a minor bump rather than a patch.
- Otherwise routine devDependency updates (ESLint, Jest, Prettier, TypeScript ESLint, micromatch); no other functional changes to `src/` since v0.8.6.

## What's Changed
* chore(deps): update dependency swr to v2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/211
* chore(deps): upgrade graphql-request to v6 by @eitoball in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/245
* chore(deps): update dependency micromatch to v4.0.8 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/230
* chore(deps): update dependency @typescript-eslint/eslint-plugin to v5.62.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/236
* chore(deps): update dependency @typescript-eslint/parser to v5.62.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/237
* chore(deps): update dependency eslint to v8.57.1 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/238
* chore(deps): update dependency eslint-config-airbnb-typescript to v17.1.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/239
* chore(deps): update dependency eslint-config-prettier to v8.10.2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/240
* chore(deps): update dependency eslint-plugin-import to v2.32.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/241
* chore(deps): update dependency eslint-plugin-jsx-a11y to v6.10.2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/246
* chore(deps): update dependency eslint-plugin-react to v7.37.5 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/247
* chore(deps): update dependency eslint-plugin-react-hooks to v4.6.2 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/248
* chore(deps): update dependency jest to v29.7.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/250
* chore(deps): update dependency jest-docblock to v29.7.0 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/251
* chore(deps): update dependency prettier to v2.8.8 by @renovate[bot] in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/252
* chore(release): bump version to 0.9.0 by @eitoball in https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/pull/255

**Full Changelog**: https://github.com/croutonn/graphql-codegen-plugin-typescript-swr/compare/v0.8.6...v0.9.0
```

Note: the `What's Changed` list above was generated via `gh api repos/croutonn/graphql-codegen-plugin-typescript-swr/releases/generate-notes -f tag_name=v0.9.0 -f previous_tag_name=v0.8.6` against the state at PR creation time. Re-run that command (or `gh release create v0.9.0 --generate-notes --notes-start-tag v0.8.6`) after merging to pick up this PR's own entry and anything merged afterward, then prepend the `## Summary` section by hand as shown above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
