### PR TITLE
fix(visitor): pass rawRequest through to SWRVisitor's config

### DIFF
--- a/sample/README.md
+++ b/sample/README.md
@@ -28,6 +28,5 @@ Uses `dev-test/githunt`'s schema and documents (the GitHunt sample schema) as-is
 
 ## Known limitations
 
-- **`rawRequest: true` is not supported.** The current plugin (`src/visitor.ts`) has a known bug where, even with `rawRequest: true`, the generated SWR hooks' types and implementation don't reflect the raw response shape and are always generated as if it were the normal response type (the plain functions on `getSdk()` do correctly handle raw responses). Combined with a recent `swr` (v2.x), this produces a type error, so this demo app excludes it from its scope.
 - **`useSWRInfinite` pagination doesn't work under swr v2.x.** Clicking "load more" on the "useSWRInfinite" tab never updates `offset` and always refetches page 1's data (the React console also shows duplicate-key warnings). The cause: the fetcher the plugin generates (`generateFetcher` in `src/visitor.ts`) assumes a 3-argument call, `(id, fieldName, fieldValue)`. This relies on swr v1's behavior of spreading an array key into the fetcher's arguments; under swr v2.5.1 the key array is instead passed as a single argument (not spread), so `fieldName` / `fieldValue` end up `undefined` and `offset` never gets merged in.
 - Next.js-specific SSR/SSG (`getStaticProps`, etc.) is not reproduced here.

--- a/sample/README.md
+++ b/sample/README.md
@@ -21,6 +21,7 @@ A React + Tailwind CSS app for manually verifying, in a real browser, that the g
 | excludeQueries | An excluded query becomes a plain Promise function instead of a hook |
 | mutation | `submitComment` / `vote` plus cache revalidation via `mutate()` |
 | Authorization | `currentUser` changes depending on whether a JWT header is present |
+| rawRequest | With `rawRequest: true`, `useComment` resolves to `SWRRawResponse<CommentQuery>` (`data`/`status`/`headers`/`errors`) instead of the plain query type |
 
 ## Schema and mock data
 

--- a/sample/codegen.yml
+++ b/sample/codegen.yml
@@ -37,3 +37,13 @@ generates:
       - typescript-operations
       - typescript-graphql-request
       - ../build/main/index.js
+  ./src/generated/sdk.rawRequest.ts:
+    schema: ../dev-test/githunt/schema.json
+    documents: ../dev-test/githunt/*.graphql
+    config:
+      rawRequest: true
+    plugins:
+      - typescript
+      - typescript-operations
+      - typescript-graphql-request
+      - ../build/main/index.js

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -5,6 +5,7 @@ import { InfiniteFeedDemo } from './demos/InfiniteFeedDemo'
 import { ExcludeQueriesDemo } from './demos/ExcludeQueriesDemo'
 import { MutationDemo } from './demos/MutationDemo'
 import { AuthorizationDemo } from './demos/AuthorizationDemo'
+import { RawRequestDemo } from './demos/RawRequestDemo'
 
 const demos = [
   { id: 'basic', label: 'Basic Query', component: BasicQueryDemo },
@@ -13,6 +14,7 @@ const demos = [
   { id: 'exclude-queries', label: 'excludeQueries', component: ExcludeQueriesDemo },
   { id: 'mutation', label: 'mutation', component: MutationDemo },
   { id: 'authorization', label: 'Authorization', component: AuthorizationDemo },
+  { id: 'raw-request', label: 'rawRequest', component: RawRequestDemo },
 ] as const
 
 function App() {

--- a/sample/src/demos/RawRequestDemo.tsx
+++ b/sample/src/demos/RawRequestDemo.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createClient } from '../client'
+import { getSdkWithHooks } from '../generated/sdk.rawRequest'
+import { setForceError } from '../mocks/data'
+
+const REPO_FULL_NAME = 'octocat/example-repo-1'
+
+export function RawRequestDemo() {
+  const [forceError, setForceErrorState] = useState(false)
+  const sdk = useMemo(() => getSdkWithHooks(createClient()), [])
+  const { data: response, error, isLoading, mutate } = sdk.useComment(['Comment:raw', REPO_FULL_NAME], {
+    repoFullName: REPO_FULL_NAME,
+  })
+
+  useEffect(() => {
+    return () => setForceError('Comment', false)
+  }, [])
+
+  const toggleError = () => {
+    const next = !forceError
+    setForceErrorState(next)
+    setForceError('Comment', next)
+    mutate()
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">rawRequest: useComment hook</h2>
+        <button
+          type="button"
+          onClick={toggleError}
+          className="rounded bg-slate-800 px-3 py-1 text-sm text-white hover:bg-slate-700"
+        >
+          {forceError ? 'Clear error' : 'Trigger error'}
+        </button>
+      </div>
+      <p className="text-sm text-slate-500">
+        Because codegen.yml sets <code>rawRequest: true</code>, <code>useComment</code> resolves to{' '}
+        <code>SWRRawResponse&lt;CommentQuery&gt;</code> instead of the plain query type. The query result now
+        lives under <code>data.data</code>, alongside <code>status</code> and <code>headers</code> from the
+        raw HTTP response.
+      </p>
+      {isLoading && <p className="text-slate-500">loading...</p>}
+      {error && <p className="text-red-600">failed to load: {error.message}</p>}
+      {response && (
+        <div className="rounded border border-slate-200 p-4">
+          <p className="text-sm text-slate-600">
+            status: <span className="font-mono">{response.status}</span>
+            {' · '}
+            content-type: <span className="font-mono">{response.headers.get('content-type')}</span>
+          </p>
+          {response.data?.entry && (
+            <div className="mt-3">
+              <p className="font-medium">{response.data.entry.repository.full_name}</p>
+              <p className="text-sm text-slate-600">{response.data.entry.repository.description}</p>
+              <ul className="mt-2 space-y-1">
+                {response.data.entry.comments.map(
+                  (comment) =>
+                    comment && (
+                      <li key={comment.id} className="text-sm">
+                        <span className="font-medium">{comment.postedBy.login}</span>: {comment.content}
+                      </li>
+                    ),
+                )}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  )
+}

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -99,6 +99,7 @@ export class SWRVisitor extends ClientSideBaseVisitor<
     rawConfig: RawSWRPluginConfig
   ) {
     super(schema, fragments, rawConfig, {
+      rawRequest: rawConfig.rawRequest || false,
       excludeQueries: rawConfig.excludeQueries || null,
       useSWRInfinite: rawConfig.useSWRInfinite || null,
       autogenSWRKey: rawConfig.autogenSWRKey || false,

--- a/tests/outputs/rawRequest.ts
+++ b/tests/outputs/rawRequest.ts
@@ -1,18 +1,19 @@
+type SWRRawResponse<Data = any> = { data?: Data | undefined; extensions?: any; headers: Headers; status: number; errors?: GraphQLError[] | undefined; };
 export function getSdkWithHooks(client: GraphQLClient, withWrapper: SdkFunctionWrapper = defaultWrapper) {
   const sdk = getSdk(client, withWrapper);
   return {
     ...sdk,
-    useFeed(key: SWRKeyInterface, variables?: FeedQueryVariables, config?: SWRConfigInterface<FeedQuery, ClientError>) {
-      return useSWR<FeedQuery, ClientError>(key, () => sdk.feed(variables), config);
+    useFeed(key: SWRKeyInterface, variables?: FeedQueryVariables, config?: SWRConfigInterface<SWRRawResponse<FeedQuery>, ClientError>) {
+      return useSWR<SWRRawResponse<FeedQuery>, ClientError>(key, () => sdk.feed(variables), config);
     },
-    useFeed2(key: SWRKeyInterface, variables: Feed2QueryVariables, config?: SWRConfigInterface<Feed2Query, ClientError>) {
-      return useSWR<Feed2Query, ClientError>(key, () => sdk.feed2(variables), config);
+    useFeed2(key: SWRKeyInterface, variables: Feed2QueryVariables, config?: SWRConfigInterface<SWRRawResponse<Feed2Query>, ClientError>) {
+      return useSWR<SWRRawResponse<Feed2Query>, ClientError>(key, () => sdk.feed2(variables), config);
     },
-    useFeed3(key: SWRKeyInterface, variables?: Feed3QueryVariables, config?: SWRConfigInterface<Feed3Query, ClientError>) {
-      return useSWR<Feed3Query, ClientError>(key, () => sdk.feed3(variables), config);
+    useFeed3(key: SWRKeyInterface, variables?: Feed3QueryVariables, config?: SWRConfigInterface<SWRRawResponse<Feed3Query>, ClientError>) {
+      return useSWR<SWRRawResponse<Feed3Query>, ClientError>(key, () => sdk.feed3(variables), config);
     },
-    useFeed4(key: SWRKeyInterface, variables?: Feed4QueryVariables, config?: SWRConfigInterface<Feed4Query, ClientError>) {
-      return useSWR<Feed4Query, ClientError>(key, () => sdk.feed4(variables), config);
+    useFeed4(key: SWRKeyInterface, variables?: Feed4QueryVariables, config?: SWRConfigInterface<SWRRawResponse<Feed4Query>, ClientError>) {
+      return useSWR<SWRRawResponse<Feed4Query>, ClientError>(key, () => sdk.feed4(variables), config);
     }
   };
 }

--- a/tests/swr.spec.ts
+++ b/tests/swr.spec.ts
@@ -13,6 +13,7 @@ import {
   TypeScriptDocumentsPluginConfig,
 } from '@graphql-codegen/typescript-operations'
 import { parse, GraphQLSchema, buildClientSchema } from 'graphql'
+import ts from 'typescript'
 
 import { RawSWRPluginConfig } from '../src/config'
 import { plugin } from '../src/index'
@@ -31,6 +32,71 @@ type PluginsConfig = Partial<
 
 const readOutput = (name: string): string =>
   fs.readFileSync(resolve(__dirname, `./outputs/${name}.ts`), 'utf-8')
+
+/**
+ * The test-only `mergeOutputs` helper concatenates each plugin's `prepend`
+ * array without deduping, unlike real codegen output, so e.g. `import gql
+ * from 'graphql-tag'` appears once per plugin that needs it. Real semantic
+ * compilation (unlike the syntax-only `validateTs`) rejects that as a
+ * duplicate identifier, so collapse repeated import lines first.
+ */
+const dedupeImportLines = (source: string): string => {
+  const seenImports = new Set<string>()
+  return source
+    .split('\n')
+    .filter((line) => {
+      const trimmed = line.trim()
+      if (!trimmed.startsWith('import ')) return true
+      if (seenImports.has(trimmed)) return false
+      seenImports.add(trimmed)
+      return true
+    })
+    .join('\n')
+}
+
+/**
+ * `validateTs` from `@graphql-codegen/testing` only parses syntax by
+ * default; it never resolves imports or checks assignability, so it can't
+ * catch a fetcher-return-type mismatch against `swr`'s own typings. This
+ * compiles the given source for real, resolving `swr` / `graphql-request`
+ * from this package's actual installed node_modules, to confirm generated
+ * hooks stay assignable to `useSWR`'s real (version-pinned) signature.
+ */
+const typeCheckAgainstInstalledDependencies = (rawSource: string): string[] => {
+  const source = dedupeImportLines(rawSource)
+  const fileName = resolve(__dirname, '__typecheck__.ts')
+  const options: ts.CompilerOptions = {
+    target: ts.ScriptTarget.ES2020,
+    module: ts.ModuleKind.CommonJS,
+    moduleResolution: ts.ModuleResolutionKind.NodeJs,
+    esModuleInterop: true,
+    skipLibCheck: true,
+    types: [],
+    lib: ['lib.es2020.d.ts', 'lib.dom.d.ts'],
+    noEmit: true,
+  }
+  const host = ts.createCompilerHost(options)
+  const getSourceFile = host.getSourceFile.bind(host)
+  host.getSourceFile = (name, languageVersion, ...rest) =>
+    resolve(name) === fileName
+      ? ts.createSourceFile(name, source, languageVersion, true)
+      : getSourceFile(name, languageVersion, ...rest)
+  host.writeFile = () => {}
+  const program = ts.createProgram([fileName], options, host)
+  return ts.getPreEmitDiagnostics(program).map((diagnostic) => {
+    const message = ts.flattenDiagnosticMessageText(
+      diagnostic.messageText,
+      '\n'
+    )
+    if (diagnostic.file && diagnostic.start !== undefined) {
+      const { line } = diagnostic.file.getLineAndCharacterOfPosition(
+        diagnostic.start
+      )
+      return `${line + 1}: ${message}`
+    }
+    return message
+  })
+}
 
 describe('SWR', () => {
   const schema = buildClientSchema(require('../dev-test/githunt/schema.json'))
@@ -76,6 +142,22 @@ async function test() {
   if (result.feed) {
     if (result.feed[0]) {
       const id = result.feed[0].id
+    }
+  }
+}`
+
+  const rawUsage = `
+async function test() {
+  const client = new GraphQLClient('');
+  const sdk = getSdkWithHooks(client);
+
+  await sdk.feed();
+  await sdk.feed3();
+  await sdk.feed4();
+  const result = await sdk.feed2({ v: "1" });
+  if (result.data?.feed) {
+    if (result.data.feed[0]) {
+      const id = result.data.feed[0].id
     }
   }
 }`
@@ -273,10 +355,15 @@ async function test() {
       outputFile: 'graphql.ts',
     })) as Types.ComplexPluginOutput
 
-    const usage = basicUsage
+    const usage = rawUsage
     const output = await validate(content, config, docs, schema, usage)
     expect(output).toContain("import { ClientError } from 'graphql-request'")
     expect(output).toContain(readOutput('rawRequest'))
+
+    // `validateTs` above only checks syntax; it can't catch a hook's fetcher
+    // being unassignable to swr's actual `useSWR` signature (the #235 bug).
+    // Compile against the real installed `swr` / `graphql-request` typings.
+    expect(typeCheckAgainstInstalledDependencies(output)).toEqual([])
   })
 
   it('Should work `typesPrefix` and `typesSuffix` option correctly', async () => {


### PR DESCRIPTION
## What
Fixes generated SWR hooks so they respect `rawRequest: true`, matching the plain SDK functions' behavior.

## Why
`SWRVisitor`'s constructor built an explicit `additionalConfig` object for `super()` that listed `excludeQueries`, `useSWRInfinite`, and `autogenSWRKey`, but omitted `rawRequest`. Since `ClientSideBaseVisitor`'s own default config doesn't include `rawRequest` either, `this.config.rawRequest` was always `undefined`, so `composeQueryHandler`'s `responseType` computation always took the non-raw branch. The generated `useSWR<...>` hooks ended up typed/implemented against the plain query type, while the underlying `sdk.xxx()` call (from `typescript-graphql-request`) actually resolved to the raw `{ data, extensions, headers, status, errors }` shape — a real mismatch against `swr`'s v2 fetcher typings.

Fixes #235

## Changes
- `src/visitor.ts`: pass `rawRequest: rawConfig.rawRequest || false` into the `additionalConfig` object given to `super()`, so `this.config.rawRequest` is actually populated.
- `tests/outputs/rawRequest.ts`: updated the expected fixture to the correct output — hooks now use `SWRRawResponse<...>` as their generic/response type when `rawRequest: true`. This fixture previously encoded the buggy (non-raw) output, which is why the existing `rawRequest` test was passing despite the bug; `tests/swr.spec.ts`'s `validateTs` call now also confirms the generated hook types actually type-check against the raw SDK response shape.
- `sample/README.md`: removed the now-stale "Known limitations" note about `rawRequest: true` not being supported.