### PR TITLE
fix: utilsForInfinite.generateFetcher should accept the SWR key as a single array

### DIFF
--- a/sample/codegen.yml
+++ b/sample/codegen.yml
@@ -27,6 +27,17 @@ generates:
       - typescript-operations
       - typescript-graphql-request
       - ../build/main/index.js
+  ./src/generated/sdk.infiniteAutogenKey.ts:
+    schema: ../dev-test/githunt/schema.json
+    documents: ../dev-test/githunt/*.graphql
+    config:
+      autogenSWRKey: true
+      useSWRInfinite: ["Feed"]
+    plugins:
+      - typescript
+      - typescript-operations
+      - typescript-graphql-request
+      - ../build/main/index.js
   ./src/generated/sdk.excluded.ts:
     schema: ../dev-test/githunt/schema.json
     documents: ../dev-test/githunt/*.graphql

--- a/sample/src/App.tsx
+++ b/sample/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { BasicQueryDemo } from './demos/BasicQueryDemo'
 import { AutogenKeyDemo } from './demos/AutogenKeyDemo'
 import { InfiniteFeedDemo } from './demos/InfiniteFeedDemo'
+import { InfiniteAutogenKeyDemo } from './demos/InfiniteAutogenKeyDemo'
 import { ExcludeQueriesDemo } from './demos/ExcludeQueriesDemo'
 import { MutationDemo } from './demos/MutationDemo'
 import { AuthorizationDemo } from './demos/AuthorizationDemo'
@@ -11,6 +12,7 @@ const demos = [
   { id: 'basic', label: 'Basic Query', component: BasicQueryDemo },
   { id: 'autogen-key', label: 'autogenSWRKey', component: AutogenKeyDemo },
   { id: 'infinite-feed', label: 'useSWRInfinite', component: InfiniteFeedDemo },
+  { id: 'infinite-autogen-key', label: 'autogenSWRKey + useSWRInfinite', component: InfiniteAutogenKeyDemo },
   { id: 'exclude-queries', label: 'excludeQueries', component: ExcludeQueriesDemo },
   { id: 'mutation', label: 'mutation', component: MutationDemo },
   { id: 'authorization', label: 'Authorization', component: AuthorizationDemo },

--- a/sample/src/demos/InfiniteAutogenKeyDemo.tsx
+++ b/sample/src/demos/InfiniteAutogenKeyDemo.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useMemo, useState } from 'react'
+import { createClient } from '../client'
+import { FeedType, getSdkWithHooks } from '../generated/sdk.infiniteAutogenKey'
+import type { FeedQuery } from '../generated/sdk.infiniteAutogenKey'
+import { setForceError } from '../mocks/data'
+
+const PAGE_SIZE = 4
+
+export function InfiniteAutogenKeyDemo() {
+  const [forceError, setForceErrorState] = useState(false)
+  const sdk = useMemo(() => getSdkWithHooks(createClient()), [])
+  // No `id` argument here: with `autogenSWRKey`, `utilsForInfinite.generateFetcher`'s
+  // first tuple element is the auto-generated `SWRKeyInterface` key, not a string.
+  // The first page also omits `offset` by returning `null` for it, exercising the
+  // key loader's `Variables[keyof Variables] | null` field-value type.
+  const { data, error, size, setSize, isLoading, mutate } = sdk.useFeedInfinite(
+    (pageIndex) => (pageIndex === 0 ? ['offset', null] : ['offset', pageIndex * PAGE_SIZE]),
+    { type: FeedType.New, limit: PAGE_SIZE },
+  )
+
+  useEffect(() => {
+    return () => setForceError('Feed', false)
+  }, [])
+
+  const toggleError = () => {
+    const next = !forceError
+    setForceErrorState(next)
+    setForceError('Feed', next)
+    mutate()
+  }
+
+  const pages = data ?? []
+  const feedEntries = pages.flatMap((page: FeedQuery) => page.feed ?? [])
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">autogenSWRKey + useSWRInfinite</h2>
+        <button
+          type="button"
+          onClick={toggleError}
+          className="rounded bg-slate-800 px-3 py-1 text-sm text-white hover:bg-slate-700"
+        >
+          {forceError ? 'Clear error' : 'Trigger error'}
+        </button>
+      </div>
+      <p className="text-sm text-slate-500">
+        Combines <code>autogenSWRKey</code> with <code>useSWRInfinite</code>: the key is
+        auto-generated (no <code>id</code> argument) and the first page passes{' '}
+        <code>offset: null</code> instead of a number.
+      </p>
+      {isLoading && <p className="text-slate-500">loading...</p>}
+      {error && <p className="text-red-600">failed to load: {error.message}</p>}
+      <ul className="space-y-2">
+        {feedEntries.map(
+          (entry) =>
+            entry && (
+              <li key={entry.id} className="rounded border border-slate-200 p-3 text-sm">
+                <span className="font-medium">{entry.repository.full_name}</span>
+                <span className="ml-2 text-slate-500">score: {entry.score}</span>
+              </li>
+            ),
+        )}
+      </ul>
+      <button
+        type="button"
+        onClick={() => setSize(size + 1)}
+        className="rounded bg-slate-800 px-3 py-1.5 text-sm text-white hover:bg-slate-700"
+      >
+        Load more
+      </button>
+    </section>
+  )
+}

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -229,9 +229,9 @@ export class SWRVisitor extends ClientSideBaseVisitor<
       return key ? [id, ...key] : null
     },
     generateFetcher: <Query = unknown, Variables = unknown>(query: (variables: Variables) => Promise<Query>, variables?: Variables) => (
-        id: string,
-        fieldName: keyof Variables,
-        fieldValue: Variables[typeof fieldName]
+        [id, fieldName, fieldValue]: [${
+          config.autogenSWRKey ? 'SWRKeyInterface' : 'string'
+        }, keyof Variables, Variables[keyof Variables] | null]
       ) => query({ ...variables, [fieldName]: fieldValue } as Variables)
   }`)
     }

--- a/tests/outputs/autogenSWRKey.ts
+++ b/tests/outputs/autogenSWRKey.ts
@@ -9,9 +9,7 @@ export function getSdkWithHooks(client: GraphQLClient, withWrapper: SdkFunctionW
       return key ? [id, ...key] : null
     },
     generateFetcher: <Query = unknown, Variables = unknown>(query: (variables: Variables) => Promise<Query>, variables?: Variables) => (
-        id: string,
-        fieldName: keyof Variables,
-        fieldValue: Variables[typeof fieldName]
+        [id, fieldName, fieldValue]: [SWRKeyInterface, keyof Variables, Variables[keyof Variables] | null]
       ) => query({ ...variables, [fieldName]: fieldValue } as Variables)
   }
   const genKey = <V extends Record<string, unknown> = Record<string, unknown>>(name: string, object: V = {} as V): SWRKeyInterface => [name, ...Object.keys(object).sort().map(key => object[key])];

--- a/tests/outputs/infinite.ts
+++ b/tests/outputs/infinite.ts
@@ -13,9 +13,7 @@ export function getSdkWithHooks(client: GraphQLClient, withWrapper: SdkFunctionW
       return key ? [id, ...key] : null
     },
     generateFetcher: <Query = unknown, Variables = unknown>(query: (variables: Variables) => Promise<Query>, variables?: Variables) => (
-        id: string,
-        fieldName: keyof Variables,
-        fieldValue: Variables[typeof fieldName]
+        [id, fieldName, fieldValue]: [string, keyof Variables, Variables[keyof Variables] | null]
       ) => query({ ...variables, [fieldName]: fieldValue } as Variables)
   }
   return {

--- a/tests/swr.spec.ts
+++ b/tests/swr.spec.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import { resolve } from 'path'
+import vm from 'vm'
 
 import { Types, mergeOutputs } from '@graphql-codegen/plugin-helpers'
 import { validateTs } from '@graphql-codegen/testing'
@@ -96,6 +97,32 @@ const typeCheckAgainstInstalledDependencies = (rawSource: string): string[] => {
     }
     return message
   })
+}
+
+// Compiles and runs the generated `utilsForInfinite` object so its behavior
+// can be exercised the same way `useSWRInfinite` calls it at runtime (which
+// type-checking alone cannot verify).
+const evaluateUtilsForInfinite = (
+  output: string
+): {
+  generateFetcher: (
+    query: (variables: unknown) => Promise<unknown>,
+    variables?: unknown
+  ) => (key: unknown) => Promise<unknown>
+} => {
+  const match = output.match(/const utilsForInfinite = (\{[\s\S]*?\n {2}\})/)
+  if (!match) {
+    throw new Error('utilsForInfinite not found in generated output')
+  }
+  const { outputText } = ts.transpileModule(`module.exports = ${match[1]};`, {
+    compilerOptions: { module: ts.ModuleKind.CommonJS },
+  })
+  const sandboxModule = { exports: {} }
+  vm.runInNewContext(outputText, {
+    module: sandboxModule,
+    exports: sandboxModule.exports,
+  })
+  return sandboxModule.exports as ReturnType<typeof evaluateUtilsForInfinite>
 }
 
 describe('SWR', () => {
@@ -326,6 +353,32 @@ async function test() {
         `import useSWRInfinite, { SWRInfiniteConfiguration } from 'swr/infinite';`
       )
       expect(output).toContain(readOutput('infinite'))
+    })
+
+    it('generateFetcher should merge variables when called the way `useSWRInfinite` calls its fetcher (a single array argument, not spread positional args)', async () => {
+      const config: PluginsConfig = {
+        useSWRInfinite: ['feed[24]'],
+      }
+      const docs = [{ location: '', document: basicDoc }]
+
+      const content = (await plugin(schema, docs, config, {
+        outputFile: 'graphql.ts',
+      })) as Types.ComplexPluginOutput
+
+      const output = await validate(content, config, docs, schema, basicUsage)
+      const { generateFetcher } = evaluateUtilsForInfinite(output)
+
+      const calls: unknown[] = []
+      const query = (variables: unknown) => {
+        calls.push(variables)
+        return Promise.resolve({})
+      }
+
+      const fetcher = generateFetcher(query, { type: 'NEW' })
+      // useSWRInfinite invokes the fetcher with the key array as ONE argument.
+      await fetcher(['feed-1', 'offset', 8])
+
+      expect(calls).toEqual([{ type: 'NEW', offset: 8 }])
     })
   })
 


### PR DESCRIPTION
## What
Fixes `utilsForInfinite.generateFetcher` in the generated SWR hooks so it correctly receives the key produced by `generateGetKey`.

## Why
`useSWRInfinite` calls its fetcher with the resolved key as **one** argument — confirmed both in SWR's `SWRInfiniteFetcher` type (`(args: T) => FetcherResponse<Data>`) and in SWR's runtime `serialize()` implementation, which passes the whole key array through as `fnArg` rather than spreading it. `generateGetKey` returns `[id, fieldName, fieldValue]` as a single array, but `generateFetcher` was destructuring three separate positional parameters `(id, fieldName, fieldValue)`. Since TypeScript's `BareFetcher` type is `(...args: any[]) => ...`, this mismatch typechecks fine but breaks at runtime — `fieldName`/`fieldValue` end up `undefined`, so the wrong field gets merged into the query variables.

Fixes #231

## Changes
- `src/visitor.ts`: `generateFetcher`'s inner function now destructures its single array argument as `[id, fieldName, fieldValue]` instead of declaring three positional parameters.
- `tests/outputs/infinite.ts`, `tests/outputs/autogenSWRKey.ts`: updated generated-code snapshots to match.
- `tests/swr.spec.ts`: added a runtime test that compiles and executes the generated `utilsForInfinite` object and invokes `generateFetcher`'s returned function the way `useSWRInfinite` actually does (single array argument), asserting the correct variables are merged. This closes a gap where the existing test suite only type-checked generated output and couldn't catch this class of bug.